### PR TITLE
Workaround for issue #832

### DIFF
--- a/conf/scripts/baasbox/core.js
+++ b/conf/scripts/baasbox/core.js
@@ -783,6 +783,13 @@ Links.save = function(params){
 };
 //---------- END Links ------
 
+
+//---------- UTILS --------
+var Utils = {}
+Utils.stringify=function(obj){
+	return JSON.stringify(obj);
+}
+
 exports.Documents = Documents;
 exports.Users = Users;
 exports.DB = DB;
@@ -791,6 +798,7 @@ exports.WS= WS;
 exports.log = log;
 exports.Links = Links;
 exports.Sessions = Sessions;
+exports.Utils = Utils;
 
 
 exports.runAsAdmin=runAsAdmin;


### PR DESCRIPTION
There is a problem with Nashorn when JSON objects are passed between different contexts.
This is the case when a plugin invokes a method exposed by another script via require/exports.
In particular this happens also with 'Box' methods because Box is implicitly imported by the plugin engine.

The workaround consists of to stringify the JSON object into the same context object that generated it.
In this way the plugin receives a plain string that can be re-parsed into a new JSON that can be accessed and manipulated.